### PR TITLE
Bump django from 5.1.4 to 5.1.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ crispy-bootstrap5==2024.2
 cryptography==43.0.1
 daphne==4.1.2
 dj-database-url==2.2.0
-Django==5.1.4
+Django==5.1.10
 django-bootstrap5==24.2
 django-crispy-forms==2.3
 django-extensions==3.2.3


### PR DESCRIPTION
### Vulnerabilities Fixed

**HTTP Response Log Injection:**
`request.path` is not escaped in logs allowing attackers to manipulate log output via crafted URLs.

**Denial-of-Service (DoS):**
- `strip_tags()` and `striptags` filter are vulnerable to slow processing of incomplete HTML tags.
- NFKC normalization on Windows causes slowdowns in `LoginView`, `LogoutView`, and `set_language` with large Unicode inputs.
- `wrap()` method and `wordwrap` filter can be exploited with very long strings.
- IPv6 validation functions and `GenericIPAddressField` form field lack input size limits enabling DoS.
